### PR TITLE
Add localhost/127.0.0.1 in the urls for which to inject the script

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Metabase - ChatGPT",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Add helper features to Metabase through requests to the OpenAI API",
   "icons": {
     "128": "chrome_icons/icon128.png",

--- a/src/background.js
+++ b/src/background.js
@@ -6,7 +6,14 @@ chrome.webNavigation.onCommitted.addListener((details) => {
   }
   const url = details.url
   const tabId = details.tabId
-  if (url.includes("metabase") && url.includes("/question")) {
+  if (
+    url.includes("/question")
+    && (
+      url.includes("metabase")
+      || url.includes("localhost")
+      || url.includes("127.0.0.1")
+    )
+  ) {
     chrome.scripting.executeScript({
       target: {tabId: tabId, allFrames: true},
       files: ['dist/content.js'],


### PR DESCRIPTION
As brought up by @Sire and @jeankri, the extension was not working at all in some cases. It seems that the problem was caused by the fact that, in the `background.js` file, the extension's content was set to be injected into the page only if the url contains the string "metabase". This was done having in mind the use of Metabase cloud or of Metabase self-hosted on a server with a host containing the word metabase. However, Metabase can also be run locally in which case the host would be "localhost" or "127.0.0.1".

Thus, this PR aims at solving the issue by including "localhost" and "127.0.0.1" in the host names for which to inject the extension's content script
