### PR TITLE
Add feature to choose model version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Metabase - ChatGPT",
-  "version": "1.3",
+  "version": "1.4",
   "description": "Add helper features to Metabase through requests to the OpenAI API",
   "icons": {
     "128": "chrome_icons/icon128.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "jest": "^29.5.0",
         "mini-css-extract-plugin": "^2.7.5",
         "webpack": "^5.80.0",
-        "webpack-cli": "^5.0.2"
+        "webpack-cli": "^5.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2423,9 +2423,9 @@
       }
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
-      "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
       "dev": true,
       "engines": {
         "node": ">=14.15.0"
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
-      "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
       "dev": true,
       "engines": {
         "node": ">=14.15.0"
@@ -2449,9 +2449,9 @@
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
-      "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
       "dev": true,
       "engines": {
         "node": ">=14.15.0"
@@ -6246,15 +6246,15 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
-      "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+      "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^2.0.1",
-        "@webpack-cli/info": "^2.0.1",
-        "@webpack-cli/serve": "^2.0.2",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
         "colorette": "^2.0.14",
         "commander": "^10.0.1",
         "cross-spawn": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jest": "^29.5.0",
     "mini-css-extract-plugin": "^2.7.5",
     "webpack": "^5.80.0",
-    "webpack-cli": "^5.0.2"
+    "webpack-cli": "^5.1.4"
   },
   "dependencies": {
     "file-loader": "^6.2.0"

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -77,7 +77,6 @@ header h1 {
   padding: 24px;
   gap: 24px;
   width: 100%;
-  height: 271px;
   border-bottom: 1px solid #878C93;
   flex: none;
   align-self: stretch;
@@ -190,5 +189,34 @@ header h1 {
   line-height: 19px;
   color: #FFFFFF;
   box-sizing: border-box;
+  cursor: pointer;
+}
+
+
+#main #model-version-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0px;
+  gap: 8px;
+  height: 35px;
+  width: 100%;
+}
+
+#main #model-version-container span, #main #model-version-container  div {
+  font-size: 16px;
+  height: 24px;
+  line-height: 24px;
+  color: #000000;
+}
+
+#main #model-version-container .model-label {
+  margin: 0px 8px 0px 0px
+}
+
+#main #model-version-container .model-button {
+  font-size: 16px;
+  margin: 0px 4px;
   cursor: pointer;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -19,6 +19,11 @@
         <span>learn more here</span>
         <img id="api-key-link-img">
       </a>
+      <div id="model-version-container">
+        <span class="model-label">Model version:</span>
+        <div class="model-button" id="gpt-3.5-turbo">gpt-3.5-turbo</div>
+        <div class="model-button" id="gpt-4">gpt-4</div>
+      </div>
       <div id="input-container">
         <p>API key:</p>
         <input type="text" name="api-key" id="api-input">

--- a/src/utils/chatgptStreamRequest.js
+++ b/src/utils/chatgptStreamRequest.js
@@ -5,23 +5,24 @@ function chatgptStreamRequest(promptMessages, streamContentCallback, errorCallba
     if (!result.metabase_chatgpt_api) {
       apiError(null, null)
     } else if (result.metabase_chatgpt_api.status !== "valid") {
-      apiError(result.metabase_chatgpt_api.key, null)
+      apiError(result.metabase_chatgpt_api, null)
     } else {
       postRequest(result.metabase_chatgpt_api, promptMessages, streamContentCallback)
     }
   });
 
-  function apiError(apiKey, errorMessage) {
+  function apiError(apiDict, errorMessage) {
     // if there was an api key, set the status to invalid
-    if (apiKey) {
+    if (apiDict.key) {
       chrome.storage.sync.set({
         metabase_chatgpt_api: {
-          ...metabase_chatgpt_api,
-          status: "invalid"
+          status: "invalid",
+          key: apiDict.key,
+          modelName: apiDict.modelName
         }
       })
     }
-    if (apiKey) {
+    if (apiDict.key) {
       errorCallback("invalid_api_key", errorMessage)
     } else {
       errorCallback("no_api_key", errorMessage)
@@ -38,7 +39,7 @@ function chatgptStreamRequest(promptMessages, streamContentCallback, errorCallba
         'Authorization': `Bearer ${apiDict.key}`
       },
       body: JSON.stringify({
-        "model": apiDict.modelName,
+        "model": apiDict.modelName || 'gpt-3.5-turbo',
         "messages": promptMessages,
         "temperature": 0,
         "stream": true,

--- a/src/utils/chatgptStreamRequest.js
+++ b/src/utils/chatgptStreamRequest.js
@@ -7,7 +7,7 @@ function chatgptStreamRequest(promptMessages, streamContentCallback, errorCallba
     } else if (result.metabase_chatgpt_api.status !== "valid") {
       apiError(result.metabase_chatgpt_api.key, null)
     } else {
-      postRequest(result.metabase_chatgpt_api.key, promptMessages, streamContentCallback)
+      postRequest(result.metabase_chatgpt_api, promptMessages, streamContentCallback)
     }
   });
 
@@ -16,7 +16,7 @@ function chatgptStreamRequest(promptMessages, streamContentCallback, errorCallba
     if (apiKey) {
       chrome.storage.sync.set({
         metabase_chatgpt_api: {
-          key: apiKey,
+          ...metabase_chatgpt_api,
           status: "invalid"
         }
       })
@@ -28,17 +28,17 @@ function chatgptStreamRequest(promptMessages, streamContentCallback, errorCallba
     }
   }
 
-  async function postRequest(apiKey, promptMessages) {
+  async function postRequest(apiDict, promptMessages) {
     // make the api request and read the reponse stream
 
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`
+        'Authorization': `Bearer ${apiDict.key}`
       },
       body: JSON.stringify({
-        "model": "gpt-4",
+        "model": apiDict.modelName,
         "messages": promptMessages,
         "temperature": 0,
         "stream": true,


### PR DESCRIPTION
New feature giving the possibility to the user of choosing what openai model to use in api requests between gpt-3.5-turbo and gpt-4. Modifications required:
- Adding the elements for the text buttons in the popup.html + the styling in popup.css
- Adding the logic of retrieving the stored version of the model and the action upon clicking on the aforementioned elements in the popup.js
- Modification of the chatgptStreamRequest.js file functions to use the stored model version instead of a hardcoded one