### PR TITLE
Update the query selector to get the openedEditorCloseLinkElement

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Metabase - ChatGPT",
-  "version": "1.5",
+  "version": "1.7",
   "description": "Add helper features to Metabase through requests to the OpenAI API",
   "icons": {
     "128": "chrome_icons/icon128.png",

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -136,7 +136,7 @@ function setupElements() {
   }
 
   function setupQueryEditingElements() {
-    var openedEditorCloseLinkElement = document.querySelector('div.NativeQueryEditor a.Query-label:not(.hide)');
+    var openedEditorCloseLinkElement = document.querySelector('[data-testid="visibility-toggler"]');
     var existingUpdateQueryContainerElement = document.getElementById(getComponentIdFromVariable({updateQueryContainerElement}))
     if (!existingUpdateQueryContainerElement && !openedEditorCloseLinkElement) {
       return

--- a/src/utils/extractDatabaseSchema.js
+++ b/src/utils/extractDatabaseSchema.js
@@ -14,7 +14,7 @@ async function extractDatabaseSchema() {
     if (Array.isArray(result[key]) && result[key].length === 0) {
         delete result[key];
     }
-});
+  });
 
   return result
 }


### PR DESCRIPTION
The issue #10 pointed out the buttons of the extension at the top of the query editor do not appear anymore for Metabase v.0.48.0

After looking at it, it turns out that Metabase modified the HTML element that was used to insert the buttons. This PR changes the way we get the element in question in a way that is compatible with both the new version and the old ones